### PR TITLE
Fix text formatting on BappDescription

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -8,8 +8,8 @@
 <p>Instructions:</p>
 <ol>
   <li>
-    Input the <em>shared secret</em> used by the Time-based One-time Password
-    Algorithm (TOTP) into Google Authenticator.
+    Input the <em>shared secret</em> used by the Time-based One-Time Password
+    (TOTP) algorithm into Google Authenticator.
   </li>
   <li>
     Input the (regular) expression to match and replace in issued request(s)

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -9,11 +9,11 @@
 <ol>
   <li>
     Input the <em>shared secret</em> used by the Time-based One-time Password
-    Algorithm (TOTP) into the Google Authenticator tab.
+    Algorithm (TOTP) into Google Authenticator.
   </li>
   <li>
-    Input the (regular) expression to replace in request(s) into the Google
-    Authenticator tab. Use the regex
+    Input the (regular) expression to match and replace in issued request(s)
+    into Google Authenticator. Use the regex
     <em>(?&lt;![\w\d])\d{6,8}(?![\w\d])</em> for optimal results as Google 2FA
     codes are made up of 6 to 8 digits according to the relevant RFCs.
   </li>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,18 +1,32 @@
 <p>
   This Burp Suite extension turns Burp into a Google Authenticator client. The
-  current Google 2FA code is automatically applied to bespoke location(s) in
-  relevant requests.
+  current Google Two-Factor Authentication (2FA) code is automatically computed
+  from a given shared secret and applied to bespoke location(s) in relevant
+  requests in real-time.
 </p>
+
 <p>Instructions:</p>
 <ol>
-  <li>Enter the <em>shared secret</em> into the Google Authenticator tab.</li>
   <li>
-    Enter a string to regular expression to replace in requests. The regular
-    expression <em>(?&lt;![\w\d])\d{6,8}(?![\w\d])</em> matches an existing OTP.
+    Input the <em>shared secret</em> used by the Time-based One-time Password
+    Algorithm (TOTP) into the Google Authenticator tab.
   </li>
   <li>
-    Configure a session handling rule that applies to relevant requests and
-    invokes the extension.
+    Input the (regular) expression to replace in request(s) into the Google
+    Authenticator tab. Use the regex
+    <em>(?&lt;![\w\d])\d{6,8}(?![\w\d])</em> for optimal results as Google 2FA
+    codes are made up of 6 to 8 digits according to the relevant RFCs.
+  </li>
+  <li>
+    Configure a session handling rule that applies to relevant request(s) and
+    invokes this extension.
   </li>
 </ol>
-<p>For more detailed instructions, consult the Github repository.</p>
+
+<p>
+  For more detailed instructions on how to use/leverage Google Auhtenticator,
+  consult the README available on the
+  <a href="https://github.com/aress31/googleauthenticator"
+    >GitHub project page</a
+  >.
+</p>

--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,12 +1,18 @@
-<p>This Burp Suite extension turns Burp into a Google Authenticator client. The current Google 2FA code is automatically applied to bespoke location(s) in relevant requests.</p>
-
+<p>
+  This Burp Suite extension turns Burp into a Google Authenticator client. The
+  current Google 2FA code is automatically applied to bespoke location(s) in
+  relevant requests.
+</p>
 <p>Instructions:</p>
-
 <ol>
-<li>Enter the <i>shared secret</i> into the Google Authenticator tab.</li>
-<li>Enter a string to regular expression to replace in requests. The regular expression <i>(?&lt;![\w\d])\d{6,8}(?![\w\d])</i> matches an existing OTP.</li>
-<li>Configure a session handling rule that applies to relevant requests and invokes the extension.</li>
-<ol>
-
+  <li>Enter the <em>shared secret</em> into the Google Authenticator tab.</li>
+  <li>
+    Enter a string to regular expression to replace in requests. The regular
+    expression <em>(?&lt;![\w\d])\d{6,8}(?![\w\d])</em> matches an existing OTP.
+  </li>
+  <li>
+    Configure a session handling rule that applies to relevant requests and
+    invokes the extension.
+  </li>
+</ol>
 <p>For more detailed instructions, consult the Github repository.</p>
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## A Burp Suite extension to apply the current Google Two-Tactor Authentication (2FA) code to relevant/selected requests.
 
-This Burp Suite extension turns Burp into a Google Authenticator client. The current Google 2FA code is automatically applied to bespoke location(s) in relevant requests.
+This Burp Suite extension turns Burp into a Google Authenticator client. The current Google `Two-Factor Authentication (2FA)` code is automatically computed from a given shared secret and applied to bespoke location(s) in relevant requests in real-time.
 
 Further information on two-factor authentication is available at the following links:
 
@@ -23,7 +23,7 @@ Further information about Burp session handling rules is available at the follow
 
 ![example](images/configuration-1.png)
 
-- Top panel: Secret shared key, used to generate the Google 2FA code using the TOTP algorithm specified in RFC4226 and RFC6238.
+- Top panel: Secret shared key, used to generate the Google 2FA code using the `Time-based One-time Password Algorithm (TOTP)` specified in `RFC4226` and `RFC6238`.
 - Left panel: Regular expression for the session handling rule to match and replace with the current Google 2FA code.
 - Right panel: Google 2FA generated code in real-time.
 
@@ -54,7 +54,7 @@ Connection: close
 
 Following the aforementioned link, we obtain the shared secret (`42TCJUDP94W27YR3`) that the `Time-based One-time Password Algorithm (TOTP)` uses to generate the Google 2FA codes.
 
-During testing, we observed that the application is being protected by a `web application firewall (WAF)`, logging our test user out each time a malicious payload is detected or if too many requests are sent in a short period of time. This configuration makes it virtually impossible to take advantage of the Burp Suite automated scan capabilities.
+During testing, we observed that the application is being protected by a `Web Application Firewall (WAF)`, logging our test user out each time a malicious payload is detected or if too many requests are sent in a short period of time. This configuration makes it virtually impossible to take advantage of the Burp Suite automated scan capabilities.
 
 ### Solution
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Further information about Burp session handling rules is available at the follow
 
 ![example](images/configuration-1.png)
 
-- Top panel: Secret shared key, used to generate the Google 2FA code using the `Time-based One-time Password Algorithm (TOTP)` specified in `RFC4226` and `RFC6238`.
+- Top panel: Secret shared key, used to generate the Google 2FA code using the `Time-based One-Time Password (TOTP)` algorithm specified in `RFC4226` and `RFC6238`.
 - Left panel: Regular expression for the session handling rule to match and replace with the current Google 2FA code.
 - Right panel: Google 2FA generated code in real-time.
 


### PR DESCRIPTION
Fix a non-closing `html` tag and reference the `README` for further explanations/examples.